### PR TITLE
Fix prefix field layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,10 @@
     </select>
 
     <label for="prefix-input">Visible Unicode Symbol</label>
-    <input id="prefix-input" type="text" placeholder="U+____">
+    <div class="prefix-field">
+        <span class="prefix-label">U+</span>
+        <input id="prefix-input" type="text" placeholder="0000">
+    </div>
 
     <textarea id="result" placeholder="Final encoded/decoded output displayed here" readonly></textarea>
 

--- a/script.js
+++ b/script.js
@@ -99,8 +99,12 @@ function parseEncodedMessage(message) {
 function parsePrefixInput() {
     const raw = prefixInput.value.trim();
     if (!raw) return '';
-    if (raw.toUpperCase().startsWith('U+')) {
-        const hex = raw.slice(2);
+    let value = raw;
+    if (/^[0-9a-fA-F]+$/.test(raw)) {
+        value = 'U+' + raw;
+    }
+    if (value.toUpperCase().startsWith('U+')) {
+        const hex = value.slice(2);
         const cp = parseInt(hex, 16);
         if (!isNaN(cp)) return String.fromCodePoint(cp);
     }

--- a/style.css
+++ b/style.css
@@ -46,3 +46,27 @@ textarea, input, select {
 textarea#result {
     height: 6rem;
 }
+
+.prefix-field {
+    display: flex;
+    align-items: center;
+}
+
+.prefix-label {
+    background: #222;
+    border: 1px solid #555;
+    border-right: none;
+    color: #eee;
+    padding: 0.5rem;
+    margin-top: 0.25rem;
+    margin-bottom: 1rem;
+}
+
+.prefix-field input {
+    flex: 1;
+    width: auto;
+    margin-top: 0.25rem;
+    margin-bottom: 1rem;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}


### PR DESCRIPTION
## Summary
- tweak prefix field layout so `U+` appears outside of the text box
- style prefix container
- allow entering only hex digits for a Unicode code point

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b4ff98ba4833181a3b22f6c6972bb