### PR TITLE
Fix prefix U+ layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,12 +52,9 @@ textarea#result {
     align-items: center;
 }
 
+
 .prefix-label {
-    background: #222;
-    border: 1px solid #555;
-    border-right: none;
-    color: #eee;
-    padding: 0.5rem;
+    margin-right: 0.5rem;
     margin-top: 0.25rem;
     margin-bottom: 1rem;
 }
@@ -67,6 +64,4 @@ textarea#result {
     width: auto;
     margin-top: 0.25rem;
     margin-bottom: 1rem;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
 }


### PR DESCRIPTION
## Summary
- adjust CSS so the fixed `U+` prefix sits outside the input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b51400cb883319e8bb94ad8da21a2